### PR TITLE
Delete tms-backend/docker.env

### DIFF
--- a/tms-backend/docker.env
+++ b/tms-backend/docker.env
@@ -1,3 +1,0 @@
-POSTGRES_DB=tms-db
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres


### PR DESCRIPTION
This pull request removes unused environment variables related to PostgreSQL configuration from the `tms-backend/docker.env` file. These variables are no longer needed as the application has transitioned to a different database setup.

Configuration cleanup:

* [`tms-backend/docker.env`](diffhunk://#diff-5f93614d75c7a271db2eb0edab9c994bbadae44314fbe7b89f09969848631286L1-L3): Removed `POSTGRES_DB`, `POSTGRES_USER`, and `POSTGRES_PASSWORD` environment variables. These were previously used for PostgreSQL configuration but are now obsolete.